### PR TITLE
Use async update in AnimatedImage and AnimatedButton

### DIFF
--- a/unity/RLottieUnity/Assets/LottiePlugin/Runtime/src/UI/AnimatedButton.cs
+++ b/unity/RLottieUnity/Assets/LottiePlugin/Runtime/src/UI/AnimatedButton.cs
@@ -143,8 +143,11 @@ namespace LottiePlugin.UI
                 _lottieAnimation.CurrentFrame <= _lottieAnimation.TotalFramesCount) ||
                 _lottieAnimation.CurrentFrame < nextState.FrameNumber)
             {
+                yield return null;
+                _lottieAnimation.UpdateAsync(_animationSpeed);
+
                 yield return _waitForEndOfFrame;
-                _lottieAnimation.Update(_animationSpeed);
+                _lottieAnimation.DrawOneFrameAsyncGetResult();
                 if (_lottieAnimation.CurrentFrame == 0)
                 {
                     _updateAnimationCoroutine = null;

--- a/unity/RLottieUnity/Assets/LottiePlugin/Runtime/src/UI/AnimatedImage.cs
+++ b/unity/RLottieUnity/Assets/LottiePlugin/Runtime/src/UI/AnimatedImage.cs
@@ -116,10 +116,16 @@ namespace LottiePlugin.UI
         {
             while (true)
             {
+                yield return null;
+                if (_lottieAnimation != null)
+                {
+                    _lottieAnimation.UpdateAsync(_animationSpeed);
+                }
+                
                 yield return _waitForEndOfFrame;
                 if (_lottieAnimation != null)
                 {
-                    _lottieAnimation.Update(_animationSpeed);
+                    _lottieAnimation.DrawOneFrameAsyncGetResult();
                     if (!_loop && _lottieAnimation.CurrentFrame == _lottieAnimation.TotalFramesCount - 1)
                     {
                         Stop();


### PR DESCRIPTION
This avoids running the internal rendering from rlottie in Unity's main thread.