### PR TITLE
Fix GitHub Actions artifact version

### DIFF
--- a/.github/workflows/activation.yaml
+++ b/.github/workflows/activation.yaml
@@ -12,7 +12,7 @@ jobs:
         uses: game-ci/unity-request-activation-file@v2
       # Upload artifact (Unity_v20XX.X.XXXX.alf)
       - name: Expose as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.getManualLicenseFile.outputs.filePath }}
           path: ${{ steps.getManualLicenseFile.outputs.filePath }}

--- a/.github/workflows/build_native_libraries.yaml
+++ b/.github/workflows/build_native_libraries.yaml
@@ -30,7 +30,7 @@ jobs:
           cmake --build ./build_x86_64 --config Release
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: LottiePluginWindowsArtifacts
           path: |
@@ -69,7 +69,7 @@ jobs:
           tree ../../out
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: LottiePluginAndroidArtifacts
           path: |
@@ -98,7 +98,7 @@ jobs:
           tree ../../out
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: LottiePluginMacOSArtifacts
           path: |
@@ -124,7 +124,7 @@ jobs:
           tree ../../out
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: LottiePluginIOSArtifacts
           path: |
@@ -150,7 +150,7 @@ jobs:
           tree ../../out
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: LottiePluginLinuxArtifacts
           path: |
@@ -183,7 +183,7 @@ jobs:
           tree out
   
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: LottiePluginWebGLArtifacts
           path: |
@@ -202,7 +202,7 @@ jobs:
   #         submodules: recursive
 
   #     - name: Download artifacts
-  #       uses: actions/download-artifact@v3
+  #       uses: actions/download-artifact@v4
   #       with:
   #         name: LottiePluginLinuxArtifacts
   #         path: out/Plugins/Linux
@@ -232,7 +232,7 @@ jobs:
   #         submodules: recursive
 
   #     - name: Download artifacts
-  #       uses: actions/download-artifact@v3
+  #       uses: actions/download-artifact@v4
   #       with:
   #         name: LottiePluginWindowsArtifacts
   #         path: out/Plugins/Windows
@@ -262,37 +262,37 @@ jobs:
           submodules: recursive
 
       - name: Download artifacts windows
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: LottiePluginWindowsArtifacts
           path: out/Plugins/Windows
 
       - name: Download artifacts android
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: LottiePluginAndroidArtifacts
           path: out/Plugins/Android
 
       - name: Download artifacts macos
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: LottiePluginMacOSArtifacts
           path: out/Plugins/Darwin
 
       - name: Download artifacts ios
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: LottiePluginIOSArtifacts
           path: out/Plugins/iOS
 
       - name: Download artifacts linux
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: LottiePluginLinuxArtifacts
           path: out/Plugins/Linux
 
       # - name: Download artifacts webgl
-      #   uses: actions/download-artifact@v3
+      #   uses: actions/download-artifact@v4
       #   with:
       #     name: LottiePluginWebGLArtifacts
       #     path: out/Plugins/WebGL


### PR DESCRIPTION
## Summary
- update artifact actions to use `actions/upload-artifact@v4`
- update artifact downloads to `actions/download-artifact@v4`
- ensure newline at end of `activation.yaml`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6845a3d6e790832f8f0c18e4ec98c58b