### PR TITLE
feat: add 16KB page size option for Android

### DIFF
--- a/.github/workflows/build_native_libraries.yaml
+++ b/.github/workflows/build_native_libraries.yaml
@@ -65,7 +65,7 @@ jobs:
           result=$(find $ANDROID_NDK_HOME -name aarch64-linux-android-strip)
           echo $result
           cd projects/AndroidStudio
-          ./gradlew assembleRelease
+          ./gradlew -PANDROID_16K_PAGE=ON assembleRelease
           tree ../../out
 
       - name: Upload artifacts

--- a/projects/AndroidStudio/app/build.gradle
+++ b/projects/AndroidStudio/app/build.gradle
@@ -21,6 +21,9 @@ android {
         externalNativeBuild {
             cmake {
                 cppFlags '-std=c++14'
+                if (project.hasProperty('ANDROID_16K_PAGE') && project.getProperty('ANDROID_16K_PAGE') == 'ON') {
+                    arguments "-DRLOTTIE_ANDROID_PAGE_SIZE_16K=ON"
+                }
             }
         }
 

--- a/projects/CMake/CMakeLists.txt
+++ b/projects/CMake/CMakeLists.txt
@@ -4,6 +4,8 @@ cmake_minimum_required (VERSION 3.6)
 #set (MSVC_RUNTIME_LIBRARY MultiThreadedDebugDLL)
 project(LottiePlugin)
 
+option(RLOTTIE_ANDROID_PAGE_SIZE_16K "Build Android libraries with 16KB page size" OFF)
+
 set(BUILD_SHARED_LIBS FALSE)
 set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 
@@ -88,6 +90,11 @@ endif()
 
 add_dependencies(LottiePlugin rlottie)
 target_link_libraries(LottiePlugin rlottie)
+
+if(ANDROID AND RLOTTIE_ANDROID_PAGE_SIZE_16K)
+  target_link_options(LottiePlugin PRIVATE "-Wl,-z,max-page-size=16384" "-Wl,-z,common-page-size=16384")
+  target_link_options(rlottie PRIVATE "-Wl,-z,max-page-size=16384" "-Wl,-z,common-page-size=16384")
+endif()
 message(${CMAKE_CURRENT_BINARY_DIR}/rlottie_build/${RLOTTIE_LIBRARY_NAME})
 
 #Adding simple test program:


### PR DESCRIPTION
## Summary
- add CMake option to link Android libs with 16KB pages
- forward Gradle property to enable the 16KB page size build
- run Android build in CI with 16KB page size

## Testing
- `git submodule update --init --recursive` *(fails: Network is unreachable)*
- `cmake -S projects/CMake -B projects/CMake/build` *(fails: dependency/rlottie missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c586853ee8832faa55676021f3a259