### PR TITLE
feat: add option for Android 16KB page size

### DIFF
--- a/.github/workflows/build_native_libraries.yaml
+++ b/.github/workflows/build_native_libraries.yaml
@@ -65,7 +65,7 @@ jobs:
           result=$(find $ANDROID_NDK_HOME -name aarch64-linux-android-strip)
           echo $result
           cd projects/AndroidStudio
-          ./gradlew assembleRelease
+          ./gradlew assembleRelease -PcmakeArgs="-DRLOTTIE_ANDROID_16K_PAGE=ON"
           tree ../../out
 
       - name: Upload artifacts

--- a/projects/CMake/CMakeLists.txt
+++ b/projects/CMake/CMakeLists.txt
@@ -7,6 +7,9 @@ project(LottiePlugin)
 set(BUILD_SHARED_LIBS FALSE)
 set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 
+# Option to enable 16 KB page size alignment for Android builds
+option(RLOTTIE_ANDROID_16K_PAGE "Align Android shared libraries for 16 KB page size" OFF)
+
 set (RLOTTIE_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../dependency/rlottie)
 set (PIXMAN_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../dependency/pixman)
 
@@ -88,6 +91,12 @@ endif()
 
 add_dependencies(LottiePlugin rlottie)
 target_link_libraries(LottiePlugin rlottie)
+
+# Enable 16 KB page size for Android if requested
+if(ANDROID AND RLOTTIE_ANDROID_16K_PAGE)
+  target_link_options(LottiePlugin PRIVATE "-Wl,-z,max-page-size=16384" "-Wl,-z,common-page-size=16384")
+endif()
+
 message(${CMAKE_CURRENT_BINARY_DIR}/rlottie_build/${RLOTTIE_LIBRARY_NAME})
 
 #Adding simple test program:


### PR DESCRIPTION
## Summary
- add optional 16KB page-size alignment for Android builds
- run Android build in CI with 16KB flag enabled

## Testing
- `cmake -S projects/CMake -B build` *(fails: missing submodule due to network)*
- `cd projects/AndroidStudio && ./gradlew -PcmakeArgs="-DRLOTTIE_ANDROID_16K_PAGE=ON" tasks` *(fails: Unable to download Gradle distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68c586853ee8832faa55676021f3a259