### PR TITLE
Generate relocatable bitcode for WebGL Unity plugin

### DIFF
--- a/.github/workflows/build_native_libraries.yaml
+++ b/.github/workflows/build_native_libraries.yaml
@@ -190,7 +190,6 @@ jobs:
           name: LottiePluginWebGLArtifacts
           path: |
             out/Plugins/WebGL/LottiePlugin.bc
-            out/Plugins/WebGL/LottiePlugin.wasm
             out/Plugins/Emscripten/x86/libLottiePlugin.a
             out/Plugins/Emscripten/x86/librlottie.a
 

--- a/projects/CMake/CMakeLists.txt
+++ b/projects/CMake/CMakeLists.txt
@@ -136,7 +136,10 @@ if (RLOTTIE_WEB_ASSEMBLY)
   )
   add_custom_command(
       TARGET LottiePlugin POST_BUILD
-      COMMAND emcc -O3 -flto -o
+      # Produce a relocatable LLVM bitcode file instead of a JavaScript glue
+      # stub. This allows Unity to statically link the plugin when building a
+      # WebGL player, avoiding runtime `dlopen` errors.
+      COMMAND emcc -O3 -flto -r -o
           "${CMAKE_CURRENT_SOURCE_DIR}/../../out/$<CONFIG>/Plugins/WebGL/LottiePlugin.bc"
           "$<TARGET_FILE:LottiePlugin>" "$<TARGET_FILE:rlottie>"
       COMMENT "Generated WebGL bitcode library")


### PR DESCRIPTION
## Summary
- build WebGL plugin as a relocatable LLVM bitcode module
- drop unused wasm artifact from workflow output

## Testing
- `cmake -S projects/CMake -B build` *(fails: missing rlottie submodule)*
- `git submodule update --init --recursive` *(fails: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b647a44c832fb46a7ec0393c3323