### PR TITLE
Ensure logger initializer export matches Linux/Android filter

### DIFF
--- a/src/LottiePlugin.cpp
+++ b/src/LottiePlugin.cpp
@@ -153,11 +153,4 @@ extern "C" {
         vDebug << "log_file_roll_size_mb: " << log_file_roll_size_mb;
         return 0;
     }
-
-    EXPORT_API int32_t initialize_logger(
-        const char* log_dir_path,
-        const char* log_file_name,
-        int32_t log_file_roll_size_mb) {
-        return lottie_initialize_logger(log_dir_path, log_file_name, log_file_roll_size_mb);
-    }
 }

--- a/src/LottiePlugin.cpp
+++ b/src/LottiePlugin.cpp
@@ -131,7 +131,10 @@ extern "C" {
         *render_data = nullptr;
         return 0;
     }
-    EXPORT_API int32_t initialize_logger(const char* log_dir_path, const char* log_file_name, int32_t log_file_roll_size_mb) {
+    EXPORT_API int32_t lottie_initialize_logger(
+        const char* log_dir_path,
+        const char* log_file_name,
+        int32_t log_file_roll_size_mb) {
         fprintf(stderr, "Initializing logger (stderr)\n");
         // print the paths
         fprintf(stderr, "log_dir_path: %s\n", log_dir_path);
@@ -149,5 +152,12 @@ extern "C" {
         vDebug << "log_file_name: " << log_file_name;
         vDebug << "log_file_roll_size_mb: " << log_file_roll_size_mb;
         return 0;
+    }
+
+    EXPORT_API int32_t initialize_logger(
+        const char* log_dir_path,
+        const char* log_file_name,
+        int32_t log_file_roll_size_mb) {
+        return lottie_initialize_logger(log_dir_path, log_file_name, log_file_roll_size_mb);
     }
 }

--- a/src/LottiePlugin.h
+++ b/src/LottiePlugin.h
@@ -57,14 +57,6 @@ extern "C" {
         const char* log_dir_path,
         const char* log_file_name,
         int32_t log_file_roll_size_mb);
-
-    // Backward compatible alias for older entry-point name. New builds should
-    // prefer `lottie_initialize_logger` to match the export filters used on
-    // Linux/Android.
-    EXPORT_API int32_t initialize_logger(
-        const char* log_dir_path,
-        const char* log_file_name,
-        int32_t log_file_roll_size_mb);
 }
 
 #endif // !_VORBIS_PLUGIN_H_

--- a/src/LottiePlugin.h
+++ b/src/LottiePlugin.h
@@ -53,6 +53,14 @@ extern "C" {
     EXPORT_API int32_t lottie_allocate_render_data(lottie_render_data** render_data);
     EXPORT_API int32_t lottie_dispose_render_data(lottie_render_data** render_data);
 
+    EXPORT_API int32_t lottie_initialize_logger(
+        const char* log_dir_path,
+        const char* log_file_name,
+        int32_t log_file_roll_size_mb);
+
+    // Backward compatible alias for older entry-point name. New builds should
+    // prefer `lottie_initialize_logger` to match the export filters used on
+    // Linux/Android.
     EXPORT_API int32_t initialize_logger(
         const char* log_dir_path,
         const char* log_file_name,

--- a/unity/RLottieUnity/Assets/LottiePlugin/Runtime/src/NativeBridge.cs
+++ b/unity/RLottieUnity/Assets/LottiePlugin/Runtime/src/NativeBridge.cs
@@ -89,7 +89,7 @@ namespace LottiePlugin
         
         [DllImport(PLUGIN_NAME,
             CallingConvention = CallingConvention.Cdecl,
-            EntryPoint = "initialize_logger")]
+            EntryPoint = "lottie_initialize_logger")]
         internal static extern int InitializeLogger(
             [MarshalAs(UnmanagedType.LPStr)] string logDirectoryPath,
             [MarshalAs(UnmanagedType.LPStr)] string logFileName,


### PR DESCRIPTION
## Summary
- rename the native logger initializer export to `lottie_initialize_logger` so it matches the Linux/Android symbol filter
- keep a compatibility alias for the old entry point and update the Unity bridge to P/Invoke the new export

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8550363e0832fb9f06650fe155f95