### PR TITLE
Add iOS simulator x86_64 build to native libraries workflow

### DIFF
--- a/.github/workflows/build_native_libraries.yaml
+++ b/.github/workflows/build_native_libraries.yaml
@@ -377,13 +377,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: LottiePluginIOSArtifacts
-          path: out/Plugins/iOS
+          path: out/Plugins/iOS/aarch64
 
       - name: Download artifacts ios-simulator-x64
         uses: actions/download-artifact@v4
         with:
           name: LottiePluginIOSSimulatorX64Artifacts
-          path: out/Plugins/iOS
+          path: out/Plugins/iOS/x86_64
 
       - name: Download artifacts linux
         uses: actions/download-artifact@v4
@@ -408,8 +408,8 @@ jobs:
           cp -f out/Plugins/Android/x86/libLottiePlugin.so unity/RLottieUnity/Assets/LottiePlugin/Plugins/Android/x86/libLottiePlugin.so
           cp -f out/Plugins/Android/x86_64/libLottiePlugin.so unity/RLottieUnity/Assets/LottiePlugin/Plugins/Android/x86_64/libLottiePlugin.so
           cp -f out/Plugins/Darwin/libLottiePlugin.dylib unity/RLottieUnity/Assets/LottiePlugin/Plugins/OSX/libLottiePlugin.dylib
-          cp -f out/Plugins/iOS/libLottiePlugin.a unity/RLottieUnity/Assets/LottiePlugin/Plugins/iOS/libLottiePlugin.a
-          cp -f out/Plugins/iOS/librlottie.a unity/RLottieUnity/Assets/LottiePlugin/Plugins/iOS/librlottie.a
+          cp -f out/Plugins/iOS/aarch64/libLottiePlugin.a unity/RLottieUnity/Assets/LottiePlugin/Plugins/iOS/libLottiePlugin.a
+          cp -f out/Plugins/iOS/aarch64/librlottie.a unity/RLottieUnity/Assets/LottiePlugin/Plugins/iOS/librlottie.a
           # iOS Simulator x86_64
           mkdir -p unity/RLottieUnity/Assets/LottiePlugin/Plugins/iOS/x86_64
           cp -f out/Plugins/iOS/x86_64/libLottiePlugin.a unity/RLottieUnity/Assets/LottiePlugin/Plugins/iOS/x86_64/libLottiePlugin.a

--- a/.github/workflows/build_native_libraries.yaml
+++ b/.github/workflows/build_native_libraries.yaml
@@ -177,6 +177,44 @@ jobs:
             out/Release/Plugins/iOS/aarch64/libLottiePlugin.a
             out/Release/Plugins/iOS/aarch64/librlottie.a
 
+  build_ios_simulator_x64:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup CMake
+        uses: jwlawson/actions-setup-cmake@v1.14
+        with:
+          cmake-version: '3.29.6'
+
+      - name: Build (iOS Simulator x86_64)
+        shell: bash
+        run: |
+          set -euxo pipefail
+          cd projects/CMake
+          # Build iOS SIMULATOR (x86_64) using the ios-cmake toolchain
+          cmake -S . -B ./buildIOSSim_x64 \
+            -G Xcode \
+            -DCMAKE_TOOLCHAIN_FILE=../../dependency/cmake-ios-toolchain/ios.toolchain.cmake \
+            -DPLATFORM=SIMULATOR64 \
+            -DARCHS=x86_64 \
+            -DRLOTTIE_IOS=1
+          cmake --build ./buildIOSSim_x64 --config Release --target LottiePlugin
+          brew install tree
+          tree ../../out || true
+
+      - name: Upload artifacts (iOS Simulator x86_64)
+        uses: actions/upload-artifact@v4
+        with:
+          name: LottiePluginIOSSimulatorX64Artifacts
+          path: |
+            out/Release/Plugins/iOS/x86_64/libLottiePlugin.a
+            out/Release/Plugins/iOS/x86_64/librlottie.a
+          if-no-files-found: error
+
   build_linux:
     runs-on: ubuntu-latest
     steps:
@@ -308,7 +346,7 @@ jobs:
   #         customParameters: -logFile -
             
   commit_and_push_native_libraries:
-    needs: [build_windows, build_android, build_macos, build_ios, build_linux, build_webgl]
+    needs: [build_windows, build_android, build_macos, build_ios, build_linux, build_webgl, build_ios_simulator_x64]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -341,6 +379,12 @@ jobs:
           name: LottiePluginIOSArtifacts
           path: out/Plugins/iOS
 
+      - name: Download artifacts ios-simulator-x64
+        uses: actions/download-artifact@v4
+        with:
+          name: LottiePluginIOSSimulatorX64Artifacts
+          path: out/Plugins/iOS
+
       - name: Download artifacts linux
         uses: actions/download-artifact@v4
         with:
@@ -366,6 +410,10 @@ jobs:
           cp -f out/Plugins/Darwin/libLottiePlugin.dylib unity/RLottieUnity/Assets/LottiePlugin/Plugins/OSX/libLottiePlugin.dylib
           cp -f out/Plugins/iOS/libLottiePlugin.a unity/RLottieUnity/Assets/LottiePlugin/Plugins/iOS/libLottiePlugin.a
           cp -f out/Plugins/iOS/librlottie.a unity/RLottieUnity/Assets/LottiePlugin/Plugins/iOS/librlottie.a
+          # iOS Simulator x86_64
+          mkdir -p unity/RLottieUnity/Assets/LottiePlugin/Plugins/iOS/x86_64
+          cp -f out/Plugins/iOS/x86_64/libLottiePlugin.a unity/RLottieUnity/Assets/LottiePlugin/Plugins/iOS/x86_64/libLottiePlugin.a
+          cp -f out/Plugins/iOS/x86_64/librlottie.a     unity/RLottieUnity/Assets/LottiePlugin/Plugins/iOS/x86_64/librlottie.a
           cp -f out/Plugins/Linux/libLottiePlugin.so unity/RLottieUnity/Assets/LottiePlugin/Plugins/Linux/x86_64/libLottiePlugin.so
           mkdir -p unity/RLottieUnity/Assets/LottiePlugin/Plugins/WebGL
           cp -f out/Plugins/WebGL/libLottiePlugin.a unity/RLottieUnity/Assets/LottiePlugin/Plugins/WebGL/libLottiePlugin.a


### PR DESCRIPTION
## Summary
- add a macOS job that builds and uploads x86_64 iOS Simulator static libraries
- publish step now waits for the simulator artifacts, downloads them, and commits the copied binaries into the Unity project

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68c87c00cf1c832faa586ebdc2b285a9