### PR TITLE
Improve async scheduling and profiling support

### DIFF
--- a/projects/CMake/CMakeLists.txt
+++ b/projects/CMake/CMakeLists.txt
@@ -9,6 +9,20 @@ option(RLOTTIE_ANDROID_PAGE_SIZE_16K "Build Android libraries with 16KB page siz
 set(BUILD_SHARED_LIBS FALSE)
 set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 
+include(CheckIPOSupported)
+check_ipo_supported(RESULT ipo_supported OUTPUT ipo_error)
+if (ipo_supported)
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE ON)
+endif()
+
+if (MSVC)
+    add_compile_options("$<$<CONFIG:Release>:/O2>" "$<$<CONFIG:Release>:/GL>")
+    add_link_options("$<$<CONFIG:Release>:/LTCG>")
+else()
+    add_compile_options("$<$<CONFIG:Release>:-O3>")
+    add_link_options("$<$<CONFIG:Release>:-flto>")
+endif()
+
 set (RLOTTIE_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../dependency/rlottie)
 set (PIXMAN_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../dependency/pixman)
 
@@ -110,6 +124,11 @@ endif()
 
 add_dependencies(LottiePlugin rlottie)
 target_link_libraries(LottiePlugin rlottie)
+
+if (ipo_supported)
+    set_property(TARGET rlottie PROPERTY INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)
+    set_property(TARGET LottiePlugin PROPERTY INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)
+endif()
 
 if (WIN32)
     # D3D11 is provided by the Windows SDK

--- a/src/LottiePlugin.cpp
+++ b/src/LottiePlugin.cpp
@@ -2,6 +2,7 @@
 #include "vdebug.h"
 
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <cstring>
 #include <functional>
@@ -12,6 +13,41 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+
+#if !defined(__EMSCRIPTEN__)
+#    include "IUnityInterface.h"
+#    include "IUnityProfiler.h"
+
+static IUnityProfiler* sProfiler = nullptr;
+static UnityProfilerMarkerDesc* sMkGetResult = nullptr;
+static UnityProfilerMarkerDesc* sMkPublish = nullptr;
+static UnityProfilerMarkerDesc* sMkUpload = nullptr;
+
+static inline void ProfBegin(UnityProfilerMarkerDesc* d)
+{
+    if (sProfiler != nullptr && sProfiler->IsAvailable() && d != nullptr)
+    {
+        sProfiler->BeginSample(d);
+    }
+}
+
+static inline void ProfEnd(UnityProfilerMarkerDesc* d)
+{
+    if (sProfiler != nullptr && sProfiler->IsAvailable() && d != nullptr)
+    {
+        sProfiler->EndSample(d);
+    }
+}
+#else
+struct UnityProfilerMarkerDesc;
+
+static inline void ProfBegin(UnityProfilerMarkerDesc*) {}
+static inline void ProfEnd(UnityProfilerMarkerDesc*) {}
+
+static UnityProfilerMarkerDesc* sMkGetResult = nullptr;
+static UnityProfilerMarkerDesc* sMkPublish = nullptr;
+static UnityProfilerMarkerDesc* sMkUpload = nullptr;
+#endif
 
 #if defined(_WIN32)
 #    include <d3d11.h>
@@ -97,6 +133,7 @@ namespace
 
     std::mutex gPendingUploadsMutex;
     std::queue<lottie_animation_wrapper*> gPendingUploads;
+    constexpr size_t kMaxPendingUploads = 32;
 
     enum UnityGfxRenderer
     {
@@ -636,12 +673,45 @@ extern "C"
         return 0;
     }
 
+    EXPORT_API int32_t lottie_render_try_get_future_result(
+        lottie_animation_wrapper* animation_wrapper,
+        lottie_render_data* render_data,
+        int32_t* ready)
+    {
+        if (render_data == nullptr || ready == nullptr)
+        {
+            return -1;
+        }
+
+        *ready = 0;
+
+        if (!render_data->render_future.valid() ||
+            render_data->render_future.wait_for(std::chrono::milliseconds(0)) != std::future_status::ready)
+        {
+            return 0;
+        }
+
+        render_data->render_future.get();
+
+        ProfBegin(sMkPublish);
+        PublishUpload(animation_wrapper, render_data);
+        ProfEnd(sMkPublish);
+
+        *ready = 1;
+        return 0;
+    }
+
     EXPORT_API int32_t lottie_render_get_future_result(
         lottie_animation_wrapper* animation_wrapper,
         lottie_render_data* render_data)
     {
+        ProfBegin(sMkGetResult);
         render_data->render_future.get();
+        ProfEnd(sMkGetResult);
+
+        ProfBegin(sMkPublish);
         PublishUpload(animation_wrapper, render_data);
+        ProfEnd(sMkPublish);
         return 0;
     }
 #endif
@@ -743,10 +813,19 @@ extern "C"
 
         state->requestedVersion.store(latest, std::memory_order_release);
         const bool enqueue = !state->uploadQueued.exchange(true, std::memory_order_acq_rel);
-        if (enqueue)
+        if (!enqueue)
         {
-            std::lock_guard<std::mutex> lock(gPendingUploadsMutex);
+            return;
+        }
+
+        std::lock_guard<std::mutex> lock(gPendingUploadsMutex);
+        if (gPendingUploads.size() < kMaxPendingUploads)
+        {
             gPendingUploads.push(animation);
+        }
+        else
+        {
+            state->uploadQueued.store(false, std::memory_order_release);
         }
     }
 
@@ -764,7 +843,9 @@ extern "C"
 
         if (animation != nullptr)
         {
+            ProfBegin(sMkUpload);
             PerformUploadFor(animation);
+            ProfEnd(sMkUpload);
         }
     }
 
@@ -773,8 +854,20 @@ extern "C"
         return OnRenderEvent;
     }
 
-    extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API UnityPluginLoad(void* /*unityInterfaces*/)
+    extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API UnityPluginLoad(void* unityInterfaces)
     {
+#if !defined(__EMSCRIPTEN__)
+        auto* ifaces = static_cast<IUnityInterfaces*>(unityInterfaces);
+        sProfiler = ifaces != nullptr ? ifaces->Get<IUnityProfiler>() : nullptr;
+        if (sProfiler != nullptr && sProfiler->IsAvailable())
+        {
+            sProfiler->CreateMarker(&sMkGetResult, "Lottie/GetFutureResult", kUnityProfilerCategoryScripts, kUnityProfilerMarkerFlagDefault, 0);
+            sProfiler->CreateMarker(&sMkPublish, "Lottie/PublishUpload", kUnityProfilerCategoryRender, kUnityProfilerMarkerFlagDefault, 0);
+            sProfiler->CreateMarker(&sMkUpload, "Lottie/PerformUpload", kUnityProfilerCategoryRender, kUnityProfilerMarkerFlagDefault, 0);
+        }
+#else
+        (void)unityInterfaces;
+#endif
     }
 
     extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API UnityPluginUnload()
@@ -805,6 +898,13 @@ extern "C"
             std::queue<lottie_animation_wrapper*> empty;
             std::swap(gPendingUploads, empty);
         }
+
+#if !defined(__EMSCRIPTEN__)
+        sProfiler = nullptr;
+        sMkGetResult = nullptr;
+        sMkPublish = nullptr;
+        sMkUpload = nullptr;
+#endif
     }
 
     extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API UnitySetGraphicsDevice(void* device, int deviceType, int eventType)

--- a/src/LottiePlugin.h
+++ b/src/LottiePlugin.h
@@ -4,6 +4,7 @@
 #include "ExportApi.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <future>
 #include <rlottie.h>
 
 #ifndef UNITY_INTERFACE_API
@@ -62,6 +63,10 @@ extern "C" {
         lottie_render_data* render_data,
         uint32_t frame_number,
         bool keep_aspect_ratio);
+    EXPORT_API int32_t lottie_render_try_get_future_result(
+        lottie_animation_wrapper* animation_wrapper,
+        lottie_render_data* render_data,
+        int32_t* ready);
     EXPORT_API int32_t lottie_render_get_future_result(
         lottie_animation_wrapper* animation_wrapper,
         lottie_render_data* render_data);

--- a/unity/RLottieUnity/Assets/LottiePlugin/Runtime/src/LottieAnimation.cs
+++ b/unity/RLottieUnity/Assets/LottiePlugin/Runtime/src/LottieAnimation.cs
@@ -8,6 +8,14 @@ using UnityEngine;
 
 namespace LottiePlugin
 {
+    public sealed class LottieAnimationOptions
+    {
+        public int TargetFps { get; set; } = 30;
+        public int ResolutionDivider { get; set; } = 1;
+        public bool PauseIfCulled { get; set; } = true;
+        public Func<bool> VisibilityEvaluator { get; set; }
+    }
+
     public sealed class LottieAnimation : IDisposable
     {
         private static bool sLoggerInitialized;
@@ -22,6 +30,26 @@ namespace LottiePlugin
         public long TotalFramesCount => _animationWrapper.totalFrames;
         public double DurationSeconds => _animationWrapper.duration;
         public bool IsPlaying { get; private set; }
+        public int TargetFps
+        {
+            get => _targetFps;
+            set
+            {
+                int clamped = Mathf.Max(1, value);
+                if (_targetFps != clamped)
+                {
+                    _targetFps = clamped;
+                    UpdateFrameDelta();
+                }
+            }
+        }
+        public int ResolutionDivider => _resolutionDivider;
+        public bool PauseIfCulled { get; set; }
+        public Func<bool> VisibilityEvaluator
+        {
+            get => _visibilityEvaluator;
+            set => _visibilityEvaluator = value;
+        }
 
         private IntPtr _animationWrapperIntPtr;
         private LottieAnimationWrapper _animationWrapper;
@@ -31,6 +59,10 @@ namespace LottiePlugin
         private NativeArray<byte> _pixelData;
         private float _timeSinceLastRenderCall;
         private double _frameDelta;
+        private double _clipFrameDelta;
+        private int _targetFps;
+        private int _resolutionDivider = 1;
+        private Func<bool> _visibilityEvaluator;
         private bool _asyncDrawWasCalled;
 
         private Action<int> DrawOneFrameCached;
@@ -38,32 +70,65 @@ namespace LottiePlugin
 
 #if !(UNITY_WEBGL && !UNITY_EDITOR)
         private IntPtr _nativeTexturePtr;
-        private static IntPtr sRenderEventFunc;
 #endif
 
-        private LottieAnimation(string jsonData, string resourcesPath, uint width, uint height)
+        private LottieAnimation(string jsonData, string resourcesPath, uint width, uint height, LottieAnimationOptions options)
         {
             ThrowIf.String.IsNullOrEmpty(jsonData, nameof(jsonData));
             ThrowIf.Value.IsZero(width, nameof(width));
             ThrowIf.Value.IsZero(height, nameof(height));
             _animationWrapper = NativeBridge.LoadFromData(jsonData, resourcesPath, out _animationWrapperIntPtr);
-            _frameDelta = _animationWrapper.duration / _animationWrapper.totalFrames;
-            CreateRenderDataTexture2DMarshalToNative(width, height);
+            _clipFrameDelta = _animationWrapper.duration / _animationWrapper.totalFrames;
+            InitializeOptions(options);
+            uint scaledWidth = ApplyResolutionDivider(width, _resolutionDivider);
+            uint scaledHeight = ApplyResolutionDivider(height, _resolutionDivider);
+            CreateRenderDataTexture2DMarshalToNative(scaledWidth, scaledHeight);
             IsPlaying = true;
             DrawOneFrameCached = DrawOneFrame;
             DrawOneFrameAsyncPrepareCached = DrawOneFrameAsyncPrepare;
         }
-        private LottieAnimation(string jsonFilePath, uint width, uint height)
+        private LottieAnimation(string jsonFilePath, uint width, uint height, LottieAnimationOptions options)
         {
             ThrowIf.String.IsNullOrEmpty(jsonFilePath, nameof(jsonFilePath));
             ThrowIf.Value.IsZero(width, nameof(width));
             ThrowIf.Value.IsZero(height, nameof(height));
             _animationWrapper = NativeBridge.LoadFromFile(jsonFilePath, out _animationWrapperIntPtr);
-            _frameDelta = _animationWrapper.duration / _animationWrapper.totalFrames;
-            CreateRenderDataTexture2DMarshalToNative(width, height);
+            _clipFrameDelta = _animationWrapper.duration / _animationWrapper.totalFrames;
+            InitializeOptions(options);
+            uint scaledWidth = ApplyResolutionDivider(width, _resolutionDivider);
+            uint scaledHeight = ApplyResolutionDivider(height, _resolutionDivider);
+            CreateRenderDataTexture2DMarshalToNative(scaledWidth, scaledHeight);
             IsPlaying = true;
             DrawOneFrameCached = DrawOneFrame;
             DrawOneFrameAsyncPrepareCached = DrawOneFrameAsyncPrepare;
+        }
+
+        private void InitializeOptions(LottieAnimationOptions options)
+        {
+            options ??= new LottieAnimationOptions();
+            _resolutionDivider = Mathf.Max(1, options.ResolutionDivider);
+            _targetFps = Mathf.Max(1, options.TargetFps);
+            PauseIfCulled = options.PauseIfCulled;
+            _visibilityEvaluator = options.VisibilityEvaluator;
+            UpdateFrameDelta();
+        }
+
+        private void UpdateFrameDelta()
+        {
+            double targetDelta = 1.0 / _targetFps;
+            _frameDelta = Math.Max(_clipFrameDelta, targetDelta);
+        }
+
+        private static uint ApplyResolutionDivider(uint value, int divider)
+        {
+            if (divider <= 1)
+            {
+                return value;
+            }
+
+            uint d = (uint)divider;
+            uint scaled = (value + d - 1u) / d;
+            return scaled == 0u ? 1u : scaled;
         }
         public void Dispose()
         {
@@ -90,11 +155,11 @@ namespace LottiePlugin
         }
         public void Update(float animationSpeed = 1f)
         {
-            UpdateInternal(animationSpeed, DrawOneFrameCached);
+            UpdateInternal(animationSpeed, DrawOneFrameCached, false);
         }
         public void UpdateAsync(float animationSpeed = 1f)
         {
-            UpdateInternal(animationSpeed, DrawOneFrameAsyncPrepareCached);
+            UpdateInternal(animationSpeed, DrawOneFrameAsyncPrepareCached, true);
             DrawOneFrameAsyncGetResult();
         }
         public void TogglePlay()
@@ -134,16 +199,22 @@ namespace LottiePlugin
         }
         public void DrawOneFrameAsyncGetResult()
         {
-            if (_asyncDrawWasCalled)
+            if (!_asyncDrawWasCalled)
             {
-                NativeBridge.LottieRenderGetFutureResult(_animationWrapperIntPtr, _lottieRenderDataIntPtr);
+                return;
+            }
+
 #if UNITY_WEBGL && !UNITY_EDITOR
-                Texture.Apply();
+            NativeBridge.LottieRenderGetFutureResult(_animationWrapperIntPtr, _lottieRenderDataIntPtr);
+            Texture.Apply();
+            _asyncDrawWasCalled = false;
 #else
+            if (NativeBridge.LottieRenderTryGetFutureResult(_animationWrapperIntPtr, _lottieRenderDataIntPtr, out int ready) == 0 && ready != 0)
+            {
                 RequestTextureUpload();
-#endif
                 _asyncDrawWasCalled = false;
             }
+#endif
         }
 
         private unsafe void CreateRenderDataTexture2DMarshalToNative(uint width, uint height)
@@ -177,30 +248,56 @@ namespace LottiePlugin
                 false,
                 false,
                 _nativeTexturePtr);
-            if (sRenderEventFunc == IntPtr.Zero)
-            {
-                sRenderEventFunc = NativeBridge.LpGetRenderEventFunc();
-            }
 #endif
             Marshal.StructureToPtr(_lottieRenderData, _lottieRenderDataIntPtr, false);
         }
-        private void UpdateInternal(float animationSpeed, Action<int> drawOneFrameMethod)
+        private void UpdateInternal(float animationSpeed, Action<int> drawOneFrameMethod, bool scheduleAsync)
         {
+            bool shouldRender = !PauseIfCulled || _visibilityEvaluator == null || _visibilityEvaluator();
+            if (!shouldRender)
+            {
+                _timeSinceLastRenderCall = 0f;
+                return;
+            }
+
             if (IsPlaying)
             {
                 _timeSinceLastRenderCall += Time.deltaTime * animationSpeed;
             }
             if (_timeSinceLastRenderCall >= _frameDelta)
             {
+                if (scheduleAsync && _asyncDrawWasCalled)
+                {
+                    return;
+                }
                 int framesDelta = Mathf.RoundToInt(_timeSinceLastRenderCall / (float)_frameDelta);
                 CurrentFrame += framesDelta;
                 if (CurrentFrame >= _animationWrapper.totalFrames)
                 {
                     CurrentFrame = 0;
                 }
-                drawOneFrameMethod(CurrentFrame);
-                _asyncDrawWasCalled = true;
-                _timeSinceLastRenderCall = 0;
+                if (scheduleAsync)
+                {
+                    if (LottieScheduler.TryStartRender())
+                    {
+                        drawOneFrameMethod(CurrentFrame);
+                        _asyncDrawWasCalled = true;
+                        _timeSinceLastRenderCall = 0f;
+                    }
+                    else
+                    {
+                        _timeSinceLastRenderCall -= framesDelta * (float)_frameDelta;
+                        if (_timeSinceLastRenderCall < 0f)
+                        {
+                            _timeSinceLastRenderCall = 0f;
+                        }
+                    }
+                }
+                else
+                {
+                    drawOneFrameMethod(CurrentFrame);
+                    _timeSinceLastRenderCall = 0f;
+                }
             }
         }
 
@@ -223,24 +320,20 @@ namespace LottiePlugin
                 }
             }
             NativeBridge.LpUpdateTexture();
-            if (sRenderEventFunc != IntPtr.Zero)
-            {
-                GL.IssuePluginEvent(sRenderEventFunc, 0);
-            }
         }
 #endif
 
-        public static LottieAnimation LoadFromJsonFile(string filePath, uint width, uint height)
+        public static LottieAnimation LoadFromJsonFile(string filePath, uint width, uint height, LottieAnimationOptions options = null)
         {
             ThrowIf.String.IsNullOrEmpty(filePath, nameof(filePath));
             InitializeLogger(Application.persistentDataPath, "rlottie.log", 1);
-            return new LottieAnimation(filePath, width, height);
+            return new LottieAnimation(filePath, width, height, options);
         }
-        public static LottieAnimation LoadFromJsonData(string jsonData, string resourcesPath, uint width, uint height)
+        public static LottieAnimation LoadFromJsonData(string jsonData, string resourcesPath, uint width, uint height, LottieAnimationOptions options = null)
         {
             ThrowIf.String.IsNullOrEmpty(jsonData, nameof(jsonData));
             InitializeLogger(Application.persistentDataPath, "rlottie.log", 1);
-            return new LottieAnimation(jsonData, resourcesPath, width, height);
+            return new LottieAnimation(jsonData, resourcesPath, width, height, options);
         }
         public static void InitializeLogger(string logDirectoryPath, string logFileName, int logFileRollSizeMB)
         {

--- a/unity/RLottieUnity/Assets/LottiePlugin/Runtime/src/LottieScheduler.cs
+++ b/unity/RLottieUnity/Assets/LottiePlugin/Runtime/src/LottieScheduler.cs
@@ -1,0 +1,37 @@
+using UnityEngine;
+
+namespace LottiePlugin
+{
+    internal static class LottieScheduler
+    {
+        public static int MaxAsyncStartsPerFrame = 6;
+        public static int MaxUploadsPerFrame = 8;
+
+        private static int sStarted;
+
+        internal static void ResetFrameBudget()
+        {
+            sStarted = 0;
+        }
+
+        internal static bool TryStartRender()
+        {
+            if (sStarted >= MaxAsyncStartsPerFrame)
+            {
+                return false;
+            }
+
+            sStarted++;
+            return true;
+        }
+    }
+
+    [DefaultExecutionOrder(int.MaxValue)]
+    internal sealed class LottieSchedulerReset : MonoBehaviour
+    {
+        private void LateUpdate()
+        {
+            LottieScheduler.ResetFrameBudget();
+        }
+    }
+}

--- a/unity/RLottieUnity/Assets/LottiePlugin/Runtime/src/LottieScheduler.cs.meta
+++ b/unity/RLottieUnity/Assets/LottiePlugin/Runtime/src/LottieScheduler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 72b5208d4a2043df803a073f71929cda
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/unity/RLottieUnity/Assets/LottiePlugin/Runtime/src/LottieUploadPump.cs
+++ b/unity/RLottieUnity/Assets/LottiePlugin/Runtime/src/LottieUploadPump.cs
@@ -1,0 +1,60 @@
+using System;
+using UnityEngine;
+
+namespace LottiePlugin
+{
+#if !(UNITY_WEBGL && !UNITY_EDITOR)
+    internal sealed class LottieUploadPump : MonoBehaviour
+    {
+        private static LottieUploadPump sInstance;
+        private static IntPtr sRenderEventFunc = IntPtr.Zero;
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        private static void EnsureInstance()
+        {
+            if (sInstance != null)
+            {
+                return;
+            }
+
+            var go = new GameObject("LottieUploadPump");
+            go.hideFlags = HideFlags.HideAndDontSave;
+            sInstance = go.AddComponent<LottieUploadPump>();
+            go.AddComponent<LottieSchedulerReset>();
+            DontDestroyOnLoad(go);
+        }
+
+        private void Awake()
+        {
+            if (sInstance != null && sInstance != this)
+            {
+                DestroyImmediate(gameObject);
+                return;
+            }
+
+            sInstance = this;
+            if (sRenderEventFunc == IntPtr.Zero)
+            {
+                sRenderEventFunc = NativeBridge.LpGetRenderEventFunc();
+            }
+        }
+
+        private void LateUpdate()
+        {
+            if (sRenderEventFunc != IntPtr.Zero)
+            {
+                GL.IssuePluginEvent(sRenderEventFunc, 0);
+            }
+        }
+
+        private void OnDestroy()
+        {
+            if (sInstance == this)
+            {
+                sInstance = null;
+                sRenderEventFunc = IntPtr.Zero;
+            }
+        }
+    }
+#endif
+}

--- a/unity/RLottieUnity/Assets/LottiePlugin/Runtime/src/LottieUploadPump.cs.meta
+++ b/unity/RLottieUnity/Assets/LottiePlugin/Runtime/src/LottieUploadPump.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 987978f6b44a4356be6f385398ace7a0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/unity/RLottieUnity/Assets/LottiePlugin/Runtime/src/NativeBridge.cs
+++ b/unity/RLottieUnity/Assets/LottiePlugin/Runtime/src/NativeBridge.cs
@@ -91,6 +91,13 @@ namespace LottiePlugin
             bool keepAspectRatio);
         [DllImport(PLUGIN_NAME,
             CallingConvention = CallingConvention.Cdecl,
+            EntryPoint = "lottie_render_try_get_future_result")]
+        internal static extern int LottieRenderTryGetFutureResult(
+            IntPtr animationWrapper,
+            IntPtr renderData,
+            out int ready);
+        [DllImport(PLUGIN_NAME,
+            CallingConvention = CallingConvention.Cdecl,
             EntryPoint = "lottie_render_get_future_result")]
         internal static extern int LottieRenderGetFutureResult(
             IntPtr animationWrapper,

--- a/unity/RLottieUnity/Assets/LottiePlugin/Runtime/src/UI/AnimatedButton.cs
+++ b/unity/RLottieUnity/Assets/LottiePlugin/Runtime/src/UI/AnimatedButton.cs
@@ -33,6 +33,9 @@ namespace LottiePlugin.UI
         [SerializeField] private bool _ignoreInputWhileAnimating = true;
         [SerializeField] private State[] _states;
         [SerializeField] private ButtonClickedEvent _onClick = new ButtonClickedEvent();
+        [SerializeField] private int _targetFps = 30;
+        [SerializeField] private int _resolutionDivider = 1;
+        [SerializeField] private bool _pauseIfCulled = true;
 
         private int _currentStateIndex;
         private LottieAnimation _lottieAnimation;
@@ -92,7 +95,8 @@ namespace LottiePlugin.UI
                 _animationJson.text,
                 string.Empty,
                 _textureWidth,
-                _textureHeight);
+                _textureHeight,
+                CreateOptions());
                 SetTextureToTheTargetRawImage();
             }
             return _lottieAnimation;
@@ -156,6 +160,25 @@ namespace LottiePlugin.UI
                 _lottieAnimation.Stop();
             }
             _updateAnimationCoroutine = null;
+        }
+
+        private LottieAnimationOptions CreateOptions()
+        {
+            return new LottieAnimationOptions
+            {
+                TargetFps = Mathf.Max(1, _targetFps),
+                ResolutionDivider = Mathf.Max(1, _resolutionDivider),
+                PauseIfCulled = _pauseIfCulled,
+                VisibilityEvaluator = () =>
+                {
+                    if (_rawImage == null)
+                    {
+                        return false;
+                    }
+
+                    return _rawImage.isActiveAndEnabled && !_rawImage.canvasRenderer.cull;
+                }
+            };
         }
     }
 }

--- a/unity/RLottieUnity/Assets/LottiePlugin/Runtime/src/UI/AnimatedImage.cs
+++ b/unity/RLottieUnity/Assets/LottiePlugin/Runtime/src/UI/AnimatedImage.cs
@@ -34,6 +34,9 @@ namespace LottiePlugin.UI
         [SerializeField] private bool _playOnAwake = true;
         [SerializeField] private bool _loop = true;
         [SerializeField] private bool _stopOnLastFrame = true;
+        [SerializeField] private int _targetFps = 30;
+        [SerializeField] private int _resolutionDivider = 1;
+        [SerializeField] private bool _pauseIfCulled = true;
 
         private LottieAnimation _lottieAnimation;
         private Coroutine _renderLottieAnimationCoroutine;
@@ -111,7 +114,8 @@ namespace LottiePlugin.UI
                 json,
                 resourcesPath,
                 width,
-                height);
+                height,
+                CreateOptions());
             _rawImage.texture = _lottieAnimation.Texture;
             _lottieAnimation.Started += OnAnimationStarted;
             _lottieAnimation.Paused += OnAnimationPaused;
@@ -138,7 +142,8 @@ namespace LottiePlugin.UI
                 _animationJson.text,
                 string.Empty,
                 _textureWidth,
-                _textureHeight);
+                _textureHeight,
+                CreateOptions());
                 _rawImage.texture = _lottieAnimation.Texture;
                 _lottieAnimation.Started += OnAnimationStarted;
                 _lottieAnimation.Paused += OnAnimationPaused;
@@ -177,6 +182,25 @@ namespace LottiePlugin.UI
         private void OnAnimationStarted(LottieAnimation animation)
         {
             Started.Invoke(this);
+        }
+
+        private LottieAnimationOptions CreateOptions()
+        {
+            return new LottieAnimationOptions
+            {
+                TargetFps = Mathf.Max(1, _targetFps),
+                ResolutionDivider = Mathf.Max(1, _resolutionDivider),
+                PauseIfCulled = _pauseIfCulled,
+                VisibilityEvaluator = () =>
+                {
+                    if (_rawImage == null)
+                    {
+                        return false;
+                    }
+
+                    return _rawImage.isActiveAndEnabled && !_rawImage.canvasRenderer.cull;
+                }
+            };
         }
         private void OnAnimationPaused(LottieAnimation animation)
         {


### PR DESCRIPTION
## Summary
- add a non-blocking render result API, queue throttling, and Unity profiler markers in the native plugin
- introduce a frame budget scheduler, upload pump, and per-animation quality controls on the C# side
- enable high optimization and LTO flags for Release builds in the CMake toolchain

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68cc76791e00832fa7f526ee1c6efd2c