### PR TITLE
Fix Unity Plugin API integration and rename exported GPU helpers

### DIFF
--- a/src/LottiePlugin.cpp
+++ b/src/LottiePlugin.cpp
@@ -19,11 +19,11 @@
 #    include "IUnityProfiler.h"
 
 static IUnityProfiler* sProfiler = nullptr;
-static UnityProfilerMarkerDesc* sMkGetResult = nullptr;
-static UnityProfilerMarkerDesc* sMkPublish = nullptr;
-static UnityProfilerMarkerDesc* sMkUpload = nullptr;
+static const UnityProfilerMarkerDesc* sMkGetResult = nullptr;
+static const UnityProfilerMarkerDesc* sMkPublish = nullptr;
+static const UnityProfilerMarkerDesc* sMkUpload = nullptr;
 
-static inline void ProfBegin(UnityProfilerMarkerDesc* d)
+static inline void ProfBegin(const UnityProfilerMarkerDesc* d)
 {
     if (sProfiler != nullptr && sProfiler->IsAvailable() && d != nullptr)
     {
@@ -31,7 +31,7 @@ static inline void ProfBegin(UnityProfilerMarkerDesc* d)
     }
 }
 
-static inline void ProfEnd(UnityProfilerMarkerDesc* d)
+static inline void ProfEnd(const UnityProfilerMarkerDesc* d)
 {
     if (sProfiler != nullptr && sProfiler->IsAvailable() && d != nullptr)
     {
@@ -39,14 +39,15 @@ static inline void ProfEnd(UnityProfilerMarkerDesc* d)
     }
 }
 #else
+struct IUnityInterfaces;
 struct UnityProfilerMarkerDesc;
 
-static inline void ProfBegin(UnityProfilerMarkerDesc*) {}
-static inline void ProfEnd(UnityProfilerMarkerDesc*) {}
+static inline void ProfBegin(const UnityProfilerMarkerDesc*) {}
+static inline void ProfEnd(const UnityProfilerMarkerDesc*) {}
 
-static UnityProfilerMarkerDesc* sMkGetResult = nullptr;
-static UnityProfilerMarkerDesc* sMkPublish = nullptr;
-static UnityProfilerMarkerDesc* sMkUpload = nullptr;
+static const UnityProfilerMarkerDesc* sMkGetResult = nullptr;
+static const UnityProfilerMarkerDesc* sMkPublish = nullptr;
+static const UnityProfilerMarkerDesc* sMkUpload = nullptr;
 #endif
 
 #if defined(_WIN32)
@@ -759,7 +760,7 @@ extern "C"
     }
 
 #if !defined(__EMSCRIPTEN__)
-    EXPORT_API void* lp_create_texture(int width, int height)
+    EXPORT_API void* lottie_create_texture(int width, int height)
     {
         InstanceState* state = GetState(gBoundAnimation);
         if (!EnsureTexture(state, width, height))
@@ -769,19 +770,19 @@ extern "C"
         return state != nullptr ? state->nativeTex : nullptr;
     }
 
-    EXPORT_API void lp_destroy_texture(void* /*tex*/)
+    EXPORT_API void lottie_destroy_texture(void* /*tex*/)
     {
         InstanceState* state = GetState(gBoundAnimation, /*create=*/false);
         ResetTextureState(state);
     }
 
-    EXPORT_API void* lp_get_native_texture_ptr(void)
+    EXPORT_API void* lottie_get_native_texture_ptr(void)
     {
         InstanceState* state = GetState(gBoundAnimation, /*create=*/false);
         return state != nullptr ? state->nativeTex : nullptr;
     }
 
-    EXPORT_API int lp_bind_lottie_instance(lottie_animation_wrapper* animation_wrapper)
+    EXPORT_API int lottie_bind_lottie_instance(lottie_animation_wrapper* animation_wrapper)
     {
         gBoundAnimation = animation_wrapper;
         if (gBoundAnimation == nullptr)
@@ -791,7 +792,7 @@ extern "C"
         return GetState(gBoundAnimation) != nullptr ? 1 : 0;
     }
 
-    EXPORT_API void lp_update_texture(void)
+    EXPORT_API void lottie_update_texture(void)
     {
         lottie_animation_wrapper* animation = gBoundAnimation;
         if (animation == nullptr)
@@ -849,16 +850,15 @@ extern "C"
         }
     }
 
-    EXPORT_API UnityRenderingEvent lp_get_render_event_func(void)
+    EXPORT_API UnityRenderingEvent lottie_get_render_event_func(void)
     {
         return OnRenderEvent;
     }
 
-    extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API UnityPluginLoad(void* unityInterfaces)
+    extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API UnityPluginLoad(IUnityInterfaces* unityInterfaces)
     {
 #if defined(HAVE_UNITY_PLUGINAPI) && !defined(__EMSCRIPTEN__)
-        auto* ifaces = static_cast<IUnityInterfaces*>(unityInterfaces);
-        sProfiler = ifaces != nullptr ? ifaces->Get<IUnityProfiler>() : nullptr;
+        sProfiler = unityInterfaces != nullptr ? unityInterfaces->Get<IUnityProfiler>() : nullptr;
         if (sProfiler != nullptr && sProfiler->IsAvailable())
         {
             sProfiler->CreateMarker(&sMkGetResult, "Lottie/GetFutureResult", kUnityProfilerCategoryScripts, kUnityProfilerMarkerFlagDefault, 0);
@@ -977,6 +977,26 @@ extern "C"
     extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API UnityRenderEvent(int eventID)
     {
         OnRenderEvent(eventID);
+    }
+
+    extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API lottie_unity_plugin_load(IUnityInterfaces* ifaces)
+    {
+        UnityPluginLoad(ifaces);
+    }
+
+    extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API lottie_unity_plugin_unload()
+    {
+        UnityPluginUnload();
+    }
+
+    extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API lottie_unity_set_graphics_device(void* device, int deviceType, int eventType)
+    {
+        UnitySetGraphicsDevice(device, deviceType, eventType);
+    }
+
+    extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API lottie_unity_render_event(int eventID)
+    {
+        UnityRenderEvent(eventID);
     }
 #endif // !__EMSCRIPTEN__
 }

--- a/src/LottiePlugin.h
+++ b/src/LottiePlugin.h
@@ -7,19 +7,22 @@
 #include <future>
 #include <rlottie.h>
 
-#ifndef UNITY_INTERFACE_API
-#   if defined(_MSC_VER)
-#       define UNITY_INTERFACE_API __stdcall
-#   else
-#       define UNITY_INTERFACE_API
+// Provide Unity macro fallbacks only when the Unity PluginAPI is unavailable.
+#if !defined(HAVE_UNITY_PLUGINAPI)
+#   ifndef UNITY_INTERFACE_API
+#       if defined(_MSC_VER)
+#           define UNITY_INTERFACE_API __stdcall
+#       else
+#           define UNITY_INTERFACE_API
+#       endif
 #   endif
-#endif
 
-#ifndef UNITY_INTERFACE_EXPORT
-#   if defined(_MSC_VER)
-#       define UNITY_INTERFACE_EXPORT __declspec(dllexport)
-#   else
-#       define UNITY_INTERFACE_EXPORT __attribute__((visibility("default")))
+#   ifndef UNITY_INTERFACE_EXPORT
+#       if defined(_MSC_VER)
+#           define UNITY_INTERFACE_EXPORT __declspec(dllexport)
+#       else
+#           define UNITY_INTERFACE_EXPORT __attribute__((visibility("default")))
+#       endif
 #   endif
 #endif
 
@@ -82,12 +85,12 @@ extern "C" {
     // GPU texture upload helpers
     typedef void (UNITY_INTERFACE_API *UnityRenderingEvent)(int eventID);
 
-    EXPORT_API void* lp_create_texture(int width, int height);
-    EXPORT_API void  lp_destroy_texture(void* tex);
-    EXPORT_API void* lp_get_native_texture_ptr(void);
-    EXPORT_API int   lp_bind_lottie_instance(lottie_animation_wrapper* animation_wrapper);
-    EXPORT_API void  lp_update_texture(void);
-    EXPORT_API UnityRenderingEvent lp_get_render_event_func(void);
+    EXPORT_API void* lottie_create_texture(int width, int height);
+    EXPORT_API void  lottie_destroy_texture(void* tex);
+    EXPORT_API void* lottie_get_native_texture_ptr(void);
+    EXPORT_API int   lottie_bind_lottie_instance(lottie_animation_wrapper* animation_wrapper);
+    EXPORT_API void  lottie_update_texture(void);
+    EXPORT_API UnityRenderingEvent lottie_get_render_event_func(void);
 }
 
 #endif // !_VORBIS_PLUGIN_H_

--- a/unity/RLottieUnity/Assets/LottiePlugin/Runtime/src/LottieAnimation.cs
+++ b/unity/RLottieUnity/Assets/LottiePlugin/Runtime/src/LottieAnimation.cs
@@ -142,11 +142,11 @@ namespace LottiePlugin
             }
             if (_nativeTexturePtr != IntPtr.Zero)
             {
-                NativeBridge.LpBindLottieInstance(_animationWrapperIntPtr);
-                NativeBridge.LpDestroyTexture(_nativeTexturePtr);
+                NativeBridge.LottieBindLottieInstance(_animationWrapperIntPtr);
+                NativeBridge.LottieDestroyTexture(_nativeTexturePtr);
                 _nativeTexturePtr = IntPtr.Zero;
             }
-            NativeBridge.LpBindLottieInstance(IntPtr.Zero);
+            NativeBridge.LottieBindLottieInstance(IntPtr.Zero);
 #endif
             NativeBridge.Dispose(_animationWrapper);
             NativeBridge.LottieDisposeRenderData(ref _lottieRenderDataIntPtr);
@@ -239,8 +239,8 @@ namespace LottiePlugin
             int bufferSize = (int)(width * height * sizeof(uint));
             _pixelData = new NativeArray<byte>(bufferSize, Allocator.Persistent, NativeArrayOptions.UninitializedMemory);
             _lottieRenderData.buffer = _pixelData.GetUnsafePtr();
-            NativeBridge.LpBindLottieInstance(_animationWrapperIntPtr);
-            _nativeTexturePtr = NativeBridge.LpCreateTexture((int)width, (int)height);
+            NativeBridge.LottieBindLottieInstance(_animationWrapperIntPtr);
+            _nativeTexturePtr = NativeBridge.LottieCreateTexture((int)width, (int)height);
             Texture = Texture2D.CreateExternalTexture(
                 (int)width,
                 (int)height,
@@ -304,9 +304,9 @@ namespace LottiePlugin
 #if !(UNITY_WEBGL && !UNITY_EDITOR)
         private void RequestTextureUpload()
         {
-            NativeBridge.LpBindLottieInstance(_animationWrapperIntPtr);
+            NativeBridge.LottieBindLottieInstance(_animationWrapperIntPtr);
 
-            IntPtr currentPtr = NativeBridge.LpGetNativeTexturePtr();
+            IntPtr currentPtr = NativeBridge.LottieGetNativeTexturePtr();
             if (currentPtr != _nativeTexturePtr)
             {
                 if (currentPtr != IntPtr.Zero)
@@ -319,7 +319,7 @@ namespace LottiePlugin
                     _nativeTexturePtr = IntPtr.Zero;
                 }
             }
-            NativeBridge.LpUpdateTexture();
+            NativeBridge.LottieUpdateTexture();
         }
 #endif
 

--- a/unity/RLottieUnity/Assets/LottiePlugin/Runtime/src/LottieUploadPump.cs
+++ b/unity/RLottieUnity/Assets/LottiePlugin/Runtime/src/LottieUploadPump.cs
@@ -35,7 +35,7 @@ namespace LottiePlugin
             sInstance = this;
             if (sRenderEventFunc == IntPtr.Zero)
             {
-                sRenderEventFunc = NativeBridge.LpGetRenderEventFunc();
+                sRenderEventFunc = NativeBridge.LottieGetRenderEventFunc();
             }
         }
 

--- a/unity/RLottieUnity/Assets/LottiePlugin/Runtime/src/NativeBridge.cs
+++ b/unity/RLottieUnity/Assets/LottiePlugin/Runtime/src/NativeBridge.cs
@@ -32,23 +32,23 @@ namespace LottiePlugin
 #endif
 
 #if !(UNITY_WEBGL && !UNITY_EDITOR)
-        [DllImport(PLUGIN_NAME, CallingConvention = CallingConvention.Cdecl, EntryPoint = "lp_create_texture")]
-        internal static extern IntPtr LpCreateTexture(int width, int height);
+        [DllImport(PLUGIN_NAME, CallingConvention = CallingConvention.Cdecl, EntryPoint = "lottie_create_texture")]
+        internal static extern IntPtr LottieCreateTexture(int width, int height);
 
-        [DllImport(PLUGIN_NAME, CallingConvention = CallingConvention.Cdecl, EntryPoint = "lp_destroy_texture")]
-        internal static extern void LpDestroyTexture(IntPtr texturePtr);
+        [DllImport(PLUGIN_NAME, CallingConvention = CallingConvention.Cdecl, EntryPoint = "lottie_destroy_texture")]
+        internal static extern void LottieDestroyTexture(IntPtr texturePtr);
 
-        [DllImport(PLUGIN_NAME, CallingConvention = CallingConvention.Cdecl, EntryPoint = "lp_get_native_texture_ptr")]
-        internal static extern IntPtr LpGetNativeTexturePtr();
+        [DllImport(PLUGIN_NAME, CallingConvention = CallingConvention.Cdecl, EntryPoint = "lottie_get_native_texture_ptr")]
+        internal static extern IntPtr LottieGetNativeTexturePtr();
 
-        [DllImport(PLUGIN_NAME, CallingConvention = CallingConvention.Cdecl, EntryPoint = "lp_bind_lottie_instance")]
-        internal static extern int LpBindLottieInstance(IntPtr animationWrapper);
+        [DllImport(PLUGIN_NAME, CallingConvention = CallingConvention.Cdecl, EntryPoint = "lottie_bind_lottie_instance")]
+        internal static extern int LottieBindLottieInstance(IntPtr animationWrapper);
 
-        [DllImport(PLUGIN_NAME, CallingConvention = CallingConvention.Cdecl, EntryPoint = "lp_update_texture")]
-        internal static extern void LpUpdateTexture();
+        [DllImport(PLUGIN_NAME, CallingConvention = CallingConvention.Cdecl, EntryPoint = "lottie_update_texture")]
+        internal static extern void LottieUpdateTexture();
 
-        [DllImport(PLUGIN_NAME, CallingConvention = CallingConvention.Cdecl, EntryPoint = "lp_get_render_event_func")]
-        internal static extern IntPtr LpGetRenderEventFunc();
+        [DllImport(PLUGIN_NAME, CallingConvention = CallingConvention.Cdecl, EntryPoint = "lottie_get_render_event_func")]
+        internal static extern IntPtr LottieGetRenderEventFunc();
 #endif
 
         [DllImport(PLUGIN_NAME,


### PR DESCRIPTION
## Summary
- align Unity plugin usage with the official interfaces by fixing the load signature, using const profiler marker descriptors, and avoiding macro redefinitions
- rename exported GPU helper functions to the lottie_* prefix and add optional lottie_unity_* aliases for Unity entry points
- update managed P/Invoke declarations and call sites to match the new native symbol names

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd9f8a6470832f8f5a176e2db52ac8