### PR TITLE
Fix disposal and NativeArray leaks in Lottie runtime

### DIFF
--- a/unity/RLottieUnity/Assets/LottiePlugin/Runtime/src/LottieAnimation.cs
+++ b/unity/RLottieUnity/Assets/LottiePlugin/Runtime/src/LottieAnimation.cs
@@ -1,5 +1,6 @@
 using LottiePlugin.Utility;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
 using Unity.Collections;
@@ -19,6 +20,8 @@ namespace LottiePlugin
     public sealed class LottieAnimation : IDisposable
     {
         private static bool sLoggerInitialized;
+        private static readonly HashSet<LottieAnimation> sAlive = new HashSet<LottieAnimation>();
+        private static readonly object sAliveLock = new object();
 
         public event Action<LottieAnimation> Started;
         public event Action<LottieAnimation> Paused;
@@ -57,6 +60,7 @@ namespace LottiePlugin
         private IntPtr _lottieRenderDataIntPtr;
         private LottieRenderData _lottieRenderData;
         private NativeArray<byte> _pixelData;
+        private bool _ownsPixelData;
         private float _timeSinceLastRenderCall;
         private double _frameDelta;
         private double _clipFrameDelta;
@@ -64,6 +68,7 @@ namespace LottiePlugin
         private int _resolutionDivider = 1;
         private Func<bool> _visibilityEvaluator;
         private bool _asyncDrawWasCalled;
+        private bool _disposed;
 
         private Action<int> DrawOneFrameCached;
         private Action<int> DrawOneFrameAsyncPrepareCached;
@@ -71,6 +76,14 @@ namespace LottiePlugin
 #if !(UNITY_WEBGL && !UNITY_EDITOR)
         private IntPtr _nativeTexturePtr;
 #endif
+
+        static LottieAnimation()
+        {
+            Application.quitting += DisposeAll;
+#if UNITY_EDITOR
+            UnityEditor.AssemblyReloadEvents.beforeAssemblyReload += DisposeAll;
+#endif
+        }
 
         private LottieAnimation(string jsonData, string resourcesPath, uint width, uint height, LottieAnimationOptions options)
         {
@@ -86,6 +99,7 @@ namespace LottiePlugin
             IsPlaying = true;
             DrawOneFrameCached = DrawOneFrame;
             DrawOneFrameAsyncPrepareCached = DrawOneFrameAsyncPrepare;
+            RegisterAliveInstance();
         }
         private LottieAnimation(string jsonFilePath, uint width, uint height, LottieAnimationOptions options)
         {
@@ -101,6 +115,7 @@ namespace LottiePlugin
             IsPlaying = true;
             DrawOneFrameCached = DrawOneFrame;
             DrawOneFrameAsyncPrepareCached = DrawOneFrameAsyncPrepare;
+            RegisterAliveInstance();
         }
 
         private void InitializeOptions(LottieAnimationOptions options)
@@ -130,16 +145,47 @@ namespace LottiePlugin
             uint scaled = (value + d - 1u) / d;
             return scaled == 0u ? 1u : scaled;
         }
+        ~LottieAnimation()
+        {
+            Dispose(false);
+        }
+
         public void Dispose()
         {
-            Started = null;
-            Paused = null;
-            Stopped = null;
-#if !(UNITY_WEBGL && !UNITY_EDITOR)
-            if (_pixelData.IsCreated)
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (_disposed)
             {
-                _pixelData.Dispose();
+                return;
             }
+
+            _disposed = true;
+
+            if (disposing)
+            {
+                Started = null;
+                Paused = null;
+                Stopped = null;
+            }
+
+            lock (sAliveLock)
+            {
+                sAlive.Remove(this);
+            }
+
+#if !(UNITY_WEBGL && !UNITY_EDITOR)
+            if (_asyncDrawWasCalled && _animationWrapperIntPtr != IntPtr.Zero && _lottieRenderDataIntPtr != IntPtr.Zero)
+            {
+                NativeBridge.LottieRenderGetFutureResult(_animationWrapperIntPtr, _lottieRenderDataIntPtr);
+                _asyncDrawWasCalled = false;
+            }
+#endif
+
+#if !(UNITY_WEBGL && !UNITY_EDITOR)
             if (_nativeTexturePtr != IntPtr.Zero)
             {
                 NativeBridge.LottieBindLottieInstance(_animationWrapperIntPtr);
@@ -148,10 +194,39 @@ namespace LottiePlugin
             }
             NativeBridge.LottieBindLottieInstance(IntPtr.Zero);
 #endif
-            NativeBridge.Dispose(_animationWrapper);
-            NativeBridge.LottieDisposeRenderData(ref _lottieRenderDataIntPtr);
-            UnityEngine.Object.DestroyImmediate(Texture);
-            Texture = null;
+
+            if (_lottieRenderDataIntPtr != IntPtr.Zero)
+            {
+                NativeBridge.LottieDisposeRenderData(ref _lottieRenderDataIntPtr);
+                _lottieRenderDataIntPtr = IntPtr.Zero;
+            }
+
+            _lottieRenderData = default;
+
+#if !(UNITY_WEBGL && !UNITY_EDITOR)
+            if (_ownsPixelData && _pixelData.IsCreated)
+            {
+                _pixelData.Dispose();
+            }
+#endif
+
+            _pixelData = default;
+            _ownsPixelData = false;
+
+            if (Texture != null)
+            {
+                UnityEngine.Object.DestroyImmediate(Texture);
+                Texture = null;
+            }
+
+            if (_animationWrapperIntPtr != IntPtr.Zero)
+            {
+                NativeBridge.Dispose(ref _animationWrapperIntPtr);
+                _animationWrapperIntPtr = IntPtr.Zero;
+            }
+
+            _animationWrapper = default;
+            _asyncDrawWasCalled = false;
         }
         public void Update(float animationSpeed = 1f)
         {
@@ -219,6 +294,11 @@ namespace LottiePlugin
 
         private unsafe void CreateRenderDataTexture2DMarshalToNative(uint width, uint height)
         {
+            if (_lottieRenderDataIntPtr != IntPtr.Zero)
+            {
+                return;
+            }
+
             NativeBridge.LottieAllocateRenderData(ref _lottieRenderDataIntPtr);
             _lottieRenderData = new LottieRenderData
             {
@@ -234,10 +314,12 @@ namespace LottiePlugin
                 0,
                 false);
             _pixelData = Texture.GetRawTextureData<byte>();
+            _ownsPixelData = false;
             _lottieRenderData.buffer = _pixelData.GetUnsafePtr();
 #else
             int bufferSize = (int)(width * height * sizeof(uint));
             _pixelData = new NativeArray<byte>(bufferSize, Allocator.Persistent, NativeArrayOptions.UninitializedMemory);
+            _ownsPixelData = true;
             _lottieRenderData.buffer = _pixelData.GetUnsafePtr();
             NativeBridge.LottieBindLottieInstance(_animationWrapperIntPtr);
             _nativeTexturePtr = NativeBridge.LottieCreateTexture((int)width, (int)height);
@@ -349,6 +431,46 @@ namespace LottiePlugin
             }
             NativeBridge.InitializeLogger(logDirectoryPath, logFileName, logFileRollSizeMB);
             sLoggerInitialized = true;
+        }
+
+        private void RegisterAliveInstance()
+        {
+            lock (sAliveLock)
+            {
+                sAlive.Add(this);
+            }
+        }
+
+        private static void DisposeAll()
+        {
+            LottieAnimation[] alive;
+            lock (sAliveLock)
+            {
+                if (sAlive.Count == 0)
+                {
+                    return;
+                }
+
+                alive = new LottieAnimation[sAlive.Count];
+                sAlive.CopyTo(alive);
+                sAlive.Clear();
+            }
+
+            foreach (LottieAnimation animation in alive)
+            {
+                if (animation == null)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    animation.Dispose();
+                }
+                catch
+                {
+                }
+            }
         }
     }
 }

--- a/unity/RLottieUnity/Assets/LottiePlugin/Runtime/src/LottieAnimationsAtlas.cs
+++ b/unity/RLottieUnity/Assets/LottiePlugin/Runtime/src/LottieAnimationsAtlas.cs
@@ -72,8 +72,15 @@ namespace LottiePlugin
         {
             for (int i = 0; i < _pixelDatas.Length; ++i)
             {
-                _pixelDatas[i].Dispose();
-                NativeBridge.Dispose(_animationWrappers[i]);
+                if (_pixelDatas[i].IsCreated)
+                {
+                    _pixelDatas[i].Dispose();
+                }
+                if (_animationWrapperIntPtrs[i] != IntPtr.Zero)
+                {
+                    NativeBridge.Dispose(ref _animationWrapperIntPtrs[i]);
+                }
+                _animationWrappers[i] = default;
                 NativeBridge.LottieDisposeRenderData(ref _lottieRenderDataIntPtrs[i]);
             }
             _pixelDatas = null;

--- a/unity/RLottieUnity/Assets/LottiePlugin/Runtime/src/NativeBridge.cs
+++ b/unity/RLottieUnity/Assets/LottiePlugin/Runtime/src/NativeBridge.cs
@@ -132,10 +132,9 @@ namespace LottiePlugin
             LottieLoadFromFile(filePath, out animationWrapper);
             return Marshal.PtrToStructure<LottieAnimationWrapper>(animationWrapper);
         }
-        internal static void Dispose(LottieAnimationWrapper lottieAnimationWrapper)
+        internal static void Dispose(ref IntPtr animationWrapperPtr)
         {
-            LottieDisposeWrapper(ref lottieAnimationWrapper.self);
-            Debug.Assert(lottieAnimationWrapper.self == IntPtr.Zero);
+            LottieDisposeWrapper(ref animationWrapperPtr);
         }
     }
 }

--- a/unity/RLottieUnity/Assets/LottiePlugin/Runtime/src/UI/AnimatedButton.cs
+++ b/unity/RLottieUnity/Assets/LottiePlugin/Runtime/src/UI/AnimatedButton.cs
@@ -63,6 +63,16 @@ namespace LottiePlugin.UI
             base.OnDestroy();
             DisposeLottieAnimation();
         }
+
+        protected override void OnDisable()
+        {
+            base.OnDisable();
+            if (_updateAnimationCoroutine != null)
+            {
+                StopCoroutine(_updateAnimationCoroutine);
+                _updateAnimationCoroutine = null;
+            }
+        }
         public void ResetState()
         {
             _currentStateIndex = 0;

--- a/unity/RLottieUnity/Assets/LottiePlugin/Runtime/src/UI/AnimatedImage.cs
+++ b/unity/RLottieUnity/Assets/LottiePlugin/Runtime/src/UI/AnimatedImage.cs
@@ -70,6 +70,15 @@ namespace LottiePlugin.UI
             DisposeLottieAnimation();
         }
 
+        private void OnDisable()
+        {
+            if (_renderLottieAnimationCoroutine != null)
+            {
+                StopCoroutine(_renderLottieAnimationCoroutine);
+                _renderLottieAnimationCoroutine = null;
+            }
+        }
+
         public void Play()
         {
             if (_renderLottieAnimationCoroutine != null)


### PR DESCRIPTION
## Summary
- fix native wrapper disposal to use the stored pointer instead of struct copies
- implement robust disposal in `LottieAnimation` including pixel buffer ownership tracking and finalizer safety net
- stop UI coroutines on disable and update atlas cleanup to match new native wrapper disposal API

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cf804bd4b0832fa9d0d0b7f3e38f2d